### PR TITLE
Fix for "Not migrating, control is locked." which may happen when {locked: "false"} instead of {locked: false}

### DIFF
--- a/migrations_server.js
+++ b/migrations_server.js
@@ -84,7 +84,7 @@ Migrations.migrateTo = function(command) {
 
   // remember to run meteor with --once otherwise it will restart
   if (subcommand === 'exit')
-    process.exit(0);
+    process.exit(0); 
 }
 
 // just returns the current version
@@ -127,17 +127,17 @@ Migrations._migrateTo = function(version, rerun) {
   // run the actual migration
   function migrate(direction, idx) {
     var migration = self._list[idx];
-
+    
     if (typeof migration[direction] !== 'function') {
-      throw new Meteor.Error('Cannot migrate ' + direction + ' on version '
+      throw new Meteor.Error('Cannot migrate ' + direction + ' on version ' 
         + migration.version);
     }
 
-    function maybeName() {
+    function maybeName() { 
       return migration.name ? ' (' + migration.name + ')' : '';
     }
 
-    console.log('Running ' + direction + '() on version '
+    console.log('Running ' + direction + '() on version ' 
       + migration.version + maybeName());
     migration[direction].call();
   }
@@ -166,7 +166,7 @@ Migrations._migrateTo = function(version, rerun) {
 }
 
 // gets the current control record, optionally creating it if non-existant
-Migrations._getControl = function() {
+Migrations._getControl = function() {  
   var control = this._collection.findOne({_id: 'control'});
 
   return control || this._setControl({version: 0, locked: false});
@@ -178,7 +178,7 @@ Migrations._setControl = function(control) {
   check(control.version, Number);
   check(control.locked, Boolean);
 
-  this._collection.update({_id: 'control'},
+  this._collection.update({_id: 'control'}, 
     {$set: {version: control.version, locked: control.locked}}, {upsert: true});
 
   return control;
@@ -188,7 +188,7 @@ Migrations._setControl = function(control) {
 Migrations._findIndexByVersion = function(version) {
   for (var i = 0;i < this._list.length;i++) {
     if (this._list[i].version === version)
-      return i;
+      return i; 
   }
 
   throw new Meteor.Error('Can\'t find migration version ' + version);

--- a/migrations_server.js
+++ b/migrations_server.js
@@ -84,7 +84,7 @@ Migrations.migrateTo = function(command) {
 
   // remember to run meteor with --once otherwise it will restart
   if (subcommand === 'exit')
-    process.exit(0); 
+    process.exit(0);
 }
 
 // just returns the current version
@@ -112,7 +112,7 @@ Migrations._migrateTo = function(version, rerun) {
     return;
   }
 
-  if (control.locked) {
+  if (control.locked === true) {
     console.log('Not migrating, control is locked.');
     return;
   }
@@ -127,17 +127,17 @@ Migrations._migrateTo = function(version, rerun) {
   // run the actual migration
   function migrate(direction, idx) {
     var migration = self._list[idx];
-    
+
     if (typeof migration[direction] !== 'function') {
-      throw new Meteor.Error('Cannot migrate ' + direction + ' on version ' 
+      throw new Meteor.Error('Cannot migrate ' + direction + ' on version '
         + migration.version);
     }
 
-    function maybeName() { 
+    function maybeName() {
       return migration.name ? ' (' + migration.name + ')' : '';
     }
 
-    console.log('Running ' + direction + '() on version ' 
+    console.log('Running ' + direction + '() on version '
       + migration.version + maybeName());
     migration[direction].call();
   }
@@ -166,7 +166,7 @@ Migrations._migrateTo = function(version, rerun) {
 }
 
 // gets the current control record, optionally creating it if non-existant
-Migrations._getControl = function() {  
+Migrations._getControl = function() {
   var control = this._collection.findOne({_id: 'control'});
 
   return control || this._setControl({version: 0, locked: false});
@@ -178,7 +178,7 @@ Migrations._setControl = function(control) {
   check(control.version, Number);
   check(control.locked, Boolean);
 
-  this._collection.update({_id: 'control'}, 
+  this._collection.update({_id: 'control'},
     {$set: {version: control.version, locked: control.locked}}, {upsert: true});
 
   return control;
@@ -188,7 +188,7 @@ Migrations._setControl = function(control) {
 Migrations._findIndexByVersion = function(version) {
   for (var i = 0;i < this._list.length;i++) {
     if (this._list[i].version === version)
-      return i; 
+      return i;
   }
 
   throw new Meteor.Error('Can\'t find migration version ' + version);


### PR DESCRIPTION
I regularly reset the locked flag with Robomongo. For lack of sleep i yesterday reset it with the value "false" (a String) instead of false (a boolean). The result: meteor-migrations refused to perform the migration, again and again, saying "Not migrating, control is locked.", and I could have torn my eyeballs out for an hour, not understanding what I was doing wrong. I think this patch will help everyone keep their sanity. I love this package, so keep it up! Would love the successive migration steps (and their failed attempts) to be logged to the migrations table to assist troubleshooting, in terms of establishing a single source of truth when it comes to the migration timeline. Other than that, very happy with it.