### PR TITLE
Update migrations_server.js

### DIFF
--- a/migrations_server.js
+++ b/migrations_server.js
@@ -35,7 +35,7 @@ Migrations = {
 }
 
 // collection holding the control record
-Migrations._collection = new Meteor.Collection('migrations');
+Migrations._collection = new Mongo.Collection('migrations');
 
 Meteor.startup(function () {
   if (process.env.MIGRATE)


### PR DESCRIPTION
`Meteor.Collection` is deprecated. This PR uses `Mongo.Collection` instead.

This also solves a bug/crash when using **matb33:collection-hooks** in production environment.