### PR TITLE
Include the migration itself as an argument to migration callbacks

### DIFF
--- a/migrations_server.js
+++ b/migrations_server.js
@@ -58,6 +58,9 @@ Migrations.add = function(migration) {
   if (migration.version <= 0)
     throw new Meteor.Error('Migration version must be greater than 0');
 
+  // Freeze the migration object to make it hereafter immutable
+  Object.freeze(migration);
+
   this._list.push(migration);
   this._list = _.sortBy(this._list, function(m) {return m.version;});
 }
@@ -139,7 +142,8 @@ Migrations._migrateTo = function(version, rerun) {
 
     console.log('Running ' + direction + '() on version ' 
       + migration.version + maybeName());
-    migration[direction].call();
+
+    migration[direction](migration);
   }
 
   // sets the current version to be locked/unlocked

--- a/migrations_tests.js
+++ b/migrations_tests.js
@@ -164,3 +164,18 @@ Tinytest.add('Checks that rerun works correctly', function(test) {
   test.equal(run, ['u1', 'u1']);
   test.equal(Migrations.getVersion(), 1);
 });
+
+Tinytest.add('Migration callbacks include the migration as an argument', function(test) {
+  var contextArg;
+  Migrations._reset();
+
+  // add the migrations
+  var migration = {
+    version: 1,
+    up: function(m) { contextArg = m; }
+  };
+  Migrations.add(migration);
+
+  Migrations.migrateTo(1);
+  test.equal(contextArg === migration, true);
+});


### PR DESCRIPTION
Include the migration itself as an argument to migration callbacks.

Fixes #34.

More subtle effects:
 - The migration objects are now frozen immediately after being added.
 - The `this` context of the migration callbacks will now default to being the migration itself.

Documentation of this new enhancement has been omitted as per @zol's [request](https://github.com/percolatestudio/meteor-migrations/issues/34#issuecomment-132273630) in #34.