### PR TITLE
Add configurable logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,50 @@ To see what version the database is at, call:
 Migrations.getVersion();
 ```
 
+### Configuration
+
+You can configure Migrations with the `config` method. Defaults are:
+
+``` javascript
+Migrations.config({
+  // Log job run details to console
+  log: true,
+
+  // Use a custom logger function (defaults to Meteor's logging package)
+  logger: null
+});
+```
+
+### Logging
+
+Migrations uses Meteor's `logging` package by default. If you want to use your
+own logger (for sending to other consumers or similar) you can do so by
+configuring the `logger` option.
+
+Migrations expects a function as `logger`, and will pass arguments to it for
+you to take action on.
+
+```js
+var MyLogger = function(opts) {
+  console.log('Level', opts.level);
+  console.log('Message', opts.message);
+  console.log('Tag', opts.tag);
+}
+
+Migrations.config({
+  logger: MyLogger
+});
+
+Migrations.add({ name: 'Test Job', ... });
+Migrations.start();
+```
+
+The `opts` object passed to `MyLogger` above includes `level`, `message`, and `tag`.
+
+- `level` will be one of `info`, `warn`, `error`, `debug`.
+- `message` is something like `Finished migrating.`.
+- `tag` will always be `"Migrations"` (handy for filtering).
+
 ### Command line use
 
 *** DEPRECATED ***

--- a/migrations_tests.js
+++ b/migrations_tests.js
@@ -183,9 +183,16 @@ Tinytest.add('Migration callbacks include the migration as an argument', functio
 Tinytest.addAsync('Migrations can log to injected logger', function(test, done) {
   Migrations._reset();
 
+  // Ensure this logging code only runs once. More than once and we get
+  // Tinytest errors that the test "returned multiple times", or "Trace: event
+  // after complete!". Give me a ping, Vasili. One ping only, please.
+  var calledDone = false;
   Migrations.options.logger = function() {
-    test.isTrue(true);
-    done();
+    if (!calledDone) {
+      calledDone = true;
+      test.isTrue(true);
+      done();
+    }
   };
 
   Migrations.add({ version: 1, up: function() { } });
@@ -197,13 +204,19 @@ Tinytest.addAsync('Migrations can log to injected logger', function(test, done) 
 Tinytest.addAsync('Migrations should pass correct arguments to logger', function(test, done) {
   Migrations._reset();
 
+  // Ensure this logging code only runs once. More than once and we get
+  // Tinytest errors that the test "returned multiple times", or "Trace: event
+  // after complete!". Give me a ping, Vasili. One ping only, please.
+  var calledDone = false;
   var logger = function(opts) {
-    test.include(opts, 'level');
-    test.include(opts, 'message');
-    test.include(opts, 'tag');
-    test.equal(opts.tag, 'Migrations');
-
-    done();
+    if (!calledDone) {
+      calledDone = true;
+      test.include(opts, 'level');
+      test.include(opts, 'message');
+      test.include(opts, 'tag');
+      test.equal(opts.tag, 'Migrations');
+      done();
+    }
   };
 
   Migrations.options.logger = logger;

--- a/migrations_tests.js
+++ b/migrations_tests.js
@@ -179,3 +179,37 @@ Tinytest.add('Migration callbacks include the migration as an argument', functio
   Migrations.migrateTo(1);
   test.equal(contextArg === migration, true);
 });
+
+Tinytest.addAsync('Migrations can log to injected logger', function(test, done) {
+  Migrations._reset();
+
+  Migrations.options.logger = function() {
+    test.isTrue(true);
+    done();
+  };
+
+  Migrations.add({ version: 1, up: function() { } });
+  Migrations.migrateTo(1);
+
+  Migrations.options.logger = null;
+});
+
+Tinytest.addAsync('Migrations should pass correct arguments to logger', function(test, done) {
+  Migrations._reset();
+
+  var logger = function(opts) {
+    test.include(opts, 'level');
+    test.include(opts, 'message');
+    test.include(opts, 'tag');
+    test.equal(opts.tag, 'Migrations');
+
+    done();
+  };
+
+  Migrations.options.logger = logger;
+
+  Migrations.add({ version: 1, up: function() { } });
+  Migrations.migrateTo(1);
+
+  Migrations.options.logger = null;
+});

--- a/package.js
+++ b/package.js
@@ -7,7 +7,7 @@ Package.describe({
 
 Package.on_use(function (api) {
   api.versionsFrom('METEOR@0.9.1.1');
-  api.use(['underscore', 'check', 'mongo'], 'server');
+  api.use(['underscore', 'check', 'mongo', 'logging'], 'server');
   api.add_files(['migrations_server.js'], "server");
   api.export('Migrations', 'server');
 });


### PR DESCRIPTION
Most of this is copied and pasted from [synced-cron](https://github.com/percolatestudio/meteor-synced-cron) code.

Note that both this and #38 are branches off master, so one of these will merge cleanly and the other will need to be updated to merge cleanly.

Closes #39.

All tests pass, but there is an error in the console:

```
(STDERR) Trace: event after complete!
(STDERR)     at [object Object].wrappedOnEvent [as onEvent] (packages/tinytest/tinytest.js:394:1)
(STDERR)     at [object Object]._.extend.ok (packages/tinytest/tinytest.js:32:1)
(STDERR)     at [object Object]._.extend.isTrue (packages/tinytest/tinytest.js:250:1)
(STDERR)     at Migrations.options.logger (packages/local-test:percolate:migrations/migrations_tests.js:187:1)
(STDERR)     at Function.<anonymous> (packages/percolate:migrations/migrations_server.js:71:1)
(STDERR)     at Function.info (packages/underscore/underscore.js:646:1)
(STDERR)     at migrate (packages/percolate:migrations/migrations_server.js:199:1)
(STDERR)     at Object.Migrations._migrateTo (packages/percolate:migrations/migrations_server.js:213:1)
(STDERR)     at Object.Migrations.migrateTo (packages/percolate:migrations/migrations_server.js:141:1)
(STDERR)     at [object Object].Tinytest.addAsync.logger [as func] (packages/local-test:percolate:migrations/migrations_tests.js:192:1)
*** Test error -- test 'Migrations can log to injected logger' returned multiple times.
```