### PR TITLE
set up TravisCI build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .build*
+node_modules/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js: "0.10"
+install:
+  - "curl https://install.meteor.com | /bin/sh"
+  - "npm install"
+before_script:
+  - "export PATH=$HOME/.meteor:$PATH"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # percolate:migrations
 
+[![Build Status](https://travis-ci.org/percolatestudio/meteor-migrations.svg?branch=master)](https://travis-ci.org/percolatestudio/meteor-migrations)
+
 A simple migration system for [Meteor](http://meteor.com) supporting up/downwards migrations and command line usage.
 
 ## Installation

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "meteor-migrations-tests",
+  "version": "0.0.1",
+  "description": "Tests for meteor-migrations.",
+  "main": "migrations_tests.js",
+  "scripts": {
+    "test": "spacejam test-packages ./"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/percolatestudio/meteor-migrations.git"
+  },
+  "author": {
+    "name": "Percolate Studio",
+    "url": "http://percolatestudio.com/"
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/percolatestudio/meteor-migrations/issues"
+  },
+  "homepage": "https://atmospherejs.com/percolate/migrations",
+  "dependencies": {
+    "spacejam": "^1.2.0"
+  },
+  "keywords": [
+    "meteor",
+    "migrations"
+  ]
+}


### PR DESCRIPTION
Just merge this then flip on the built at TravisCI to automatically run tests every time commits are pushed to the percolatestudio/meteor-migrations repo at GitHub.