### PR TITLE
add lastLocked field to control document

### DIFF
--- a/migrations_server.js
+++ b/migrations_server.js
@@ -213,7 +213,7 @@ Migrations._migrateTo = function(version, rerun) {
     // the unlocked control, and locking occurs in the same update's modifier.
     // All other simultaneous callers will get false back from the update.
     return self._collection.update(
-      {_id: 'control', locked: false}, {$set: {locked: true}}
+      {_id: 'control', locked: false}, {$set: {locked: true, lastLocked: new Date()}}
     ) === 1;
   }
 


### PR DESCRIPTION
`lastLocked` is set to the current date whenever `lock()` succeeds.

This provides more information about the migration lock and allows, for example, timing out migrations.