### PR TITLE
48 custom name for migration collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ Migrations.config({
 
   // Enable/disable logging "Not migrating, already at version {number}"
   logIfLatest: true
+
+  // migrations collection name to use in the database
+  collectionName: "migrations"
 });
 ```
 
@@ -135,6 +138,10 @@ The `opts` object passed to `MyLogger` above includes `level`, `message`, and `t
 - `level` will be one of `info`, `warn`, `error`, `debug`.
 - `message` is something like `Finished migrating.`.
 - `tag` will always be `"Migrations"` (handy for filtering).
+
+### Custom collection name
+
+By default, the collection name is **migrations**. There may be cases where this is inadequate such as using the same Mongo database for multiple Meteor applications that each have their own set of migrations that need to be run.
 
 ### Command line use
 

--- a/migrations_server.js
+++ b/migrations_server.js
@@ -38,7 +38,9 @@ Migrations = {
     // null or a function
     logger: null,
     // enable/disable info log "already at latest."
-    logIfLatest: true
+    logIfLatest: true,
+		// migrations collection name
+		collectionName: "migrations"
   },
   config: function(opts) {
     this.options = _.extend({}, this.options, opts);
@@ -84,11 +86,14 @@ function createLogger(prefix) {
 
 var log;
 
-// collection holding the control record
-Migrations._collection = new Mongo.Collection('migrations');
+// // collection holding the control record
+// Migrations._collection = new Mongo.Collection('migrations');
 
 Meteor.startup(function () {
   var options = Migrations.options;
+
+	// collection holding the control record
+	Migrations._collection = new Mongo.Collection(options.collectionName);
 
   log = createLogger('Migrations');
 

--- a/migrations_server.js
+++ b/migrations_server.js
@@ -86,9 +86,6 @@ function createLogger(prefix) {
 
 var log;
 
-// // collection holding the control record
-// Migrations._collection = new Mongo.Collection('migrations');
-
 Meteor.startup(function () {
   var options = Migrations.options;
 

--- a/migrations_server.js
+++ b/migrations_server.js
@@ -39,8 +39,8 @@ Migrations = {
     logger: null,
     // enable/disable info log "already at latest."
     logIfLatest: true,
-		// migrations collection name
-		collectionName: "migrations"
+    // migrations collection name
+    collectionName: "migrations"
   },
   config: function(opts) {
     this.options = _.extend({}, this.options, opts);
@@ -92,8 +92,8 @@ var log;
 Meteor.startup(function () {
   var options = Migrations.options;
 
-	// collection holding the control record
-	Migrations._collection = new Mongo.Collection(options.collectionName);
+  // collection holding the control record
+  Migrations._collection = new Mongo.Collection(options.collectionName);
 
   log = createLogger('Migrations');
 

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Define and run db migrations.",
-  version: "0.9.7",
+  version: "0.9.8",
   name: "percolate:migrations",
   git: "https://github.com/percolatestudio/meteor-migrations.git"
 });


### PR DESCRIPTION
This fixes issue #48 by adding the ability to config the package to use a custom name for the migrations collection. We have a use case for this at our company and thought it was worthwhile contributing a patch for it.