### PR TITLE
Update current version after every migration

### DIFF
--- a/migrations_server.js
+++ b/migrations_server.js
@@ -235,15 +235,21 @@ Migrations._migrateTo = function(version, rerun) {
     self._setControl({ locked: false, version: currentVersion });
   }
 
+  function updateVersion() {
+    self._setControl({ locked: true, version: currentVersion });
+  }
+
   if (currentVersion < version) {
     for (var i = startIdx; i < endIdx; i++) {
       migrate('up', i + 1);
       currentVersion = self._list[i + 1].version;
+      updateVersion();
     }
   } else {
     for (var i = startIdx; i > endIdx; i--) {
       migrate('down', i);
       currentVersion = self._list[i - 1].version;
+      updateVersion();
     }
   }
 

--- a/migrations_tests.js
+++ b/migrations_tests.js
@@ -178,6 +178,43 @@ Tinytest.add('Checks that locking works correctly', function(test) {
   test.equal(Migrations.getVersion(), 1);
 });
 
+Tinytest.add('Checks that version is updated if subsequent migration fails', function(test) {
+  var run = [];
+  var shouldError = true;
+  Migrations._reset();
+
+  // add the migrations
+  Migrations.add({
+    version: 1,
+    up: function() {
+      run.push('u1');
+    },
+  });
+  Migrations.add({
+    version: 2,
+    up: function() {
+      if (shouldError) {
+        throw new Error('Error in migration');
+      }
+      run.push('u2');
+    },
+  });
+
+  // migrate up, which should throw
+  test.throws(function() {
+    Migrations.migrateTo('latest');
+  });
+  test.equal(run, ['u1']);
+  test.equal(Migrations.getVersion(), 1);
+
+  shouldError = false;
+  // migrate up again, should succeed
+  Migrations.unlock();
+  Migrations.migrateTo('latest');
+  test.equal(run, ['u1', 'u2']);
+  test.equal(Migrations.getVersion(), 2);
+});
+
 Tinytest.add('Does nothing for no migrations.', function(test) {
   Migrations._reset();
 


### PR DESCRIPTION
Previously, if there were multiple pending migrations and a later
migration failed, the current version would still be set to before the
first migration of the series. That's inaccurate, since the earlier
migrations in the series did run successfully, and running those
migrations multiple times may not be idempotent (and is almost certainly
unexpected).

Instead, store the current version after each migration, but keep
control locked until the series finishes.